### PR TITLE
Handle VMFS5's double indirect pointer for files > 256G

### DIFF
--- a/libvmfs/vmfs_file.c
+++ b/libvmfs/vmfs_file.c
@@ -205,6 +205,11 @@ ssize_t vmfs_file_pread(vmfs_file_t *f,u_char *buf,size_t len,off_t pos)
             break;
          }
 
+         /* Pointer-Block, if we get here we failed to resolve pointer */
+         case VMFS_BLK_TYPE_PB:
+            fprintf(stderr, "VMFS: Pointer block at id 0x%8.8x\n", blk_id);
+            return(-EINVAL);
+
          /* Inline in the inode */
          case VMFS_BLK_TYPE_FD:
             if (blk_id == f->inode->id) {

--- a/libvmfs/vmfs_inode.c
+++ b/libvmfs/vmfs_inode.c
@@ -318,7 +318,7 @@ int vmfs_inode_get_block(const vmfs_inode_t *inode,off_t pos,uint32_t *blk_id)
          } else {
             pointer_result = vmfs_sp_get_block(fs, inode, pos, blk_id);
          }
-         if(pointer_result) {
+         if (pointer_result) {
             fprintf(stderr, "Error in resolving pointer block: %d\n",
                               pointer_result);
             return(pointer_result);

--- a/libvmfs/vmfs_inode.h
+++ b/libvmfs/vmfs_inode.h
@@ -26,6 +26,9 @@
 
 #define VMFS_INODE_MAGIC  0x10c00001
 
+#define VMFS_DP_BLOCK_SZ 0x100000
+#define VMFS_SP_MAX_SZ 0x4000000000
+
 struct vmfs_inode_raw {
    struct vmfs_metadata_hdr_raw mdh;
    uint32_t id;
@@ -135,6 +138,12 @@ int vmfs_inode_alloc(vmfs_fs_t *fs,u_int type,mode_t mode,vmfs_inode_t **inode);
  * resolution is transparently done here.
  */
 int vmfs_inode_get_block(const vmfs_inode_t *inode,off_t pos,uint32_t *blk_id);
+
+/* Get block id from pointer block */
+int vmfs_sp_get_block(const vmfs_fs_t *fs, const vmfs_inode_t *inode, off_t pos, uint32_t *blk_id);
+
+/* Get block id from double indirect pointer block */
+int vmfs_dp_get_block(const vmfs_fs_t *fs, const vmfs_inode_t *inode, off_t pos, uint32_t *blk_id);
 
 /* Get a block for writing corresponding to the specified position */
 int vmfs_inode_get_wrblock(vmfs_inode_t *inode,off_t pos,uint32_t *blk_id);


### PR DESCRIPTION
```
https://github.com/glandium/vmfs-tools/issues/12
```

This provides read support for files > 256G, due to vSphere 5
adding double indirect block pointers. It uses a double indirect
lookup if the file has a blocksize of 1M and is over the VMFS size
threshold for using double indirect blocks. Perhaps there's a cleaner
way of determining the use of double indirect from the inode.

We may also want to implement a block pointer cache like VMware introduced
with this feature, however given the use cases of this software it may
not be necessary.
